### PR TITLE
Bump build base version to v1.23.11b1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
-ARG GO_IMAGE=rancher/hardened-build-base:v1.23.12b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.23.11b1
 
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.6.1 AS xx

--- a/updatecli/updatecli.d/updatebuildbase.yaml
+++ b/updatecli/updatecli.d/updatebuildbase.yaml
@@ -1,6 +1,5 @@
 ---
 name: "Update build base version"
-
 sources:
   upstream:
     name: Get upstream release
@@ -15,35 +14,32 @@ sources:
         prerelease: false
       versionfilter:
         kind: semver
-
   gomod:
     name: Get latest Golang version based on go.mod
     kind: file
     dependson:
       - upstream
     spec:
-      file: https://raw.githubusercontent.com/{{ .scm.buildbase.owner }}/{{ .scm.buildbase.repository }}/{{ source upstream }}/go.mod
+      file: https://raw.githubusercontent.com/{{ .scm.upstream.owner }}/{{ .scm.upstream.repository }}/{{ source "upstream" }}/go.mod
       matchpattern: 'go ([0-9]+\.[0-9]+)'
     transformers:
       - trimprefix: "go "
-
   buildbase:
-   name: Get build base version
-   kind: githubrelease
-   dependson:
-     - "gomod"
-   spec:
-     token: '{{ requiredEnv .github.token }}'
-     owner: '{{ .scm.buildbase.owner }}'
-     repository: '{{ .scm.buildbase.repository }}'
-     typefilter:
-       release: true
-       draft: false
-       prerelease: false
-     versionfilter:
-       kind: regex
-       pattern: '{{ source "gomod"}}\.\S+'
-
+    name: Get build base version
+    kind: githubrelease
+    dependson:
+      - "gomod"
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      owner: '{{ .scm.buildbase.owner }}'
+      repository: '{{ .scm.buildbase.repository }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        pattern: '{{ source "gomod"}}\.\S+'
 targets:
   dockerfile:
     name: "Bump to latest build base version in Dockerfile"
@@ -57,7 +53,6 @@ targets:
         matcher: "GO_IMAGE"
     transformers:
       - addprefix: "rancher/hardened-build-base:"
-
 scms:
   default:
     kind: github
@@ -69,16 +64,14 @@ scms:
       owner: '{{ .scm.default.owner }}'
       repository: '{{ .scm.default.repository }}'
       branch: '{{ .scm.default.branch }}'
-
 actions:
-    default:
-        title: 'Bump build base version to {{ source "buildbase" }}'
-        kind: github/pullrequest
-        spec:
-            automerge: false
-            labels:
-                - chore
-                - skip-changelog
-                - status/auto-created
-        scmid: default
-
+  default:
+    title: 'Bump build base version to {{ source "buildbase" }}'
+    kind: github/pullrequest
+    spec:
+      automerge: false
+      labels:
+        - chore
+        - skip-changelog
+        - status/auto-created
+    scmid: default

--- a/updatecli/updatecli.d/updatebuildbase.yaml
+++ b/updatecli/updatecli.d/updatebuildbase.yaml
@@ -2,11 +2,27 @@
 name: "Update build base version"
 
 sources:
+  upstream:
+    name: Get upstream release
+    kind: githubrelease
+    spec:
+      owner: '{{ .scm.upstream.owner }}'
+      repository: '{{ .scm.upstream.repository }}'
+      token: '{{ requiredEnv .github.token }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: semver
+
   gomod:
     name: Get latest Golang version based on go.mod
     kind: file
+    dependson:
+      - upstream
     spec:
-      file: https://raw.githubusercontent.com/{{ .scm.buildbase.owner }}/{{ .scm.buildbase.repository }}/master/go.mod
+      file: https://raw.githubusercontent.com/{{ .scm.buildbase.owner }}/{{ .scm.buildbase.repository }}/{{ source upstream }}/go.mod
       matchpattern: 'go ([0-9]+\.[0-9]+)'
     transformers:
       - trimprefix: "go "

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -5,9 +5,9 @@ github:
   token: "UPDATECLI_GITHUB_TOKEN"
 scm:
   default:
-    owner: "rancher"
+    owner: "mgfritch"
     repository: "image-build-sriov-operator"
-    branch: "main"
+    branch: "updatecli"
   upstream:
     owner: "k8snetworkplumbingwg"
     repository: "sriov-network-operator"


### PR DESCRIPTION



<Actions>
    <action id="d7f92eb0a3abcc03eb3474bea328769484d749891e0e93b7e9b5db417816ef2d">
        <h3>Update build base version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest build base version in Dockerfile</summary>
            <p>changed lines [2] of file &#34;/tmp/updatecli/github/mgfritch/image-build-sriov-operator/Dockerfile&#34;</p>
            <details>
                <summary>v1.23.11b1</summary>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

